### PR TITLE
fix(router): ensure proper route initialization and component rendering

### DIFF
--- a/src/lib/instance.svelte.ts
+++ b/src/lib/instance.svelte.ts
@@ -36,8 +36,6 @@ export class Instance {
     this.#pre = pre;
     this.#post = post;
 
-    this.run(this.current);
-
     // Setup a history watcher to navigate to the current route:
     window.addEventListener("pushState", (event: Event) => {
       this.run(get(this, this.routes, location.pathname));

--- a/src/lib/router.svelte
+++ b/src/lib/router.svelte
@@ -19,5 +19,7 @@
 </script>
 
 {#if instance.current}
-  <instance.current.component params={instance.current.params} {...instance.current.props} />
+  {#key instance.current.component}
+    <instance.current.component params={instance.current.params} {...instance.current.props} />
+  {/key}
 {/if}

--- a/src/lib/router.svelte
+++ b/src/lib/router.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Writable } from "svelte/store";
-  import { Instance, setupHistoryWatcher, type PostHooks, type PreHooks, type Route } from "./instance.svelte";
+  import { Instance, setupHistoryWatcher, get, type PostHooks, type PreHooks, type Route } from "./instance.svelte";
 
   type Props = {
     pre?: PreHooks;
@@ -16,6 +16,12 @@
   navigating = instance.navigating;
 
   setupHistoryWatcher(instance);
+
+  // Use the existing get function to find the initial route
+  $effect.pre(() => {
+    const route = get(instance, routes, location.pathname);
+    if (route) instance.run(route);
+  });
 </script>
 
 {#if instance.current}


### PR DESCRIPTION
During startup, the initial route component wasn't rendering properly because the route.run() was called too early in the Instance constructor, before the component was fully mounted on the client-side. Moved the initial route.run() call to $effect.pre to ensure it happens after component mounting.

Also added {#key} block around the component rendering to ensure proper component lifecycle management. The key block is necessary because in Svelte 5 with runes, when the route changes, we need to fully destroy and recreate the component instance to prevent state bleeding between different routes and ensure clean component initialization.