### PR TITLE
export Router was not found

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,9 +1,6 @@
 export { route } from "./actions/route";
 export type { Route } from "./instance.svelte";
 export { goto, query } from "./methods";
-export * from "./router.svelte";
-export { Instance as default, QueryString, Router };
-import { Instance } from "./instance.svelte";
-import { QueryString } from "./query.svelte";
-import Router from "./router.svelte";
-
+export { default as Router } from "./router.svelte";
+export { Instance } from "./instance.svelte";
+export { QueryString } from "./query.svelte";


### PR DESCRIPTION
When trying the latest version 0.1.35, I saw this message:

Message:  The export "Router" in "../svelte5-router/dist/index.js" has no internal name (existing names: )

I traced it down to 0.1.28, where it still was working, 0.1.29 was not working anymore. There I saw that index.ts changed, and I added:

export { default as Router } from "./router.svelte";

I am also not sure why there are imports (I left them out.)