### PR TITLE
fix: compare matches to inbound params, parse number 0

### DIFF
--- a/src/lib/query.svelte.ts
+++ b/src/lib/query.svelte.ts
@@ -81,11 +81,12 @@ export class Query {
     if (typeof inbound === "object") {
       const matches: Record<string, ReturnParam> = {};
       for (const [key, test] of Object.entries(inbound.params)) {
-        if (this.params[key] || this.params[key] === 0) {
+        const value = this.params[key];
+        if (typeof value !== 'undefined' && value !== null) {
           const marshalled = marshal(this.params[key]);
           if (test instanceof RegExp) {
             const res = evaluators.any[Identities.regexp](test, this.params[key]);
-            if (res || res === 0) {
+            if (typeof res !== 'undefined' && res !== null) {
               matches[key] = res;
             } else {
               return {

--- a/src/lib/query.svelte.ts
+++ b/src/lib/query.svelte.ts
@@ -81,11 +81,11 @@ export class Query {
     if (typeof inbound === "object") {
       const matches: Record<string, ReturnParam> = {};
       for (const [key, test] of Object.entries(inbound.params)) {
-        if (this.params[key]) {
+        if (this.params[key] || this.params[key] === 0) {
           const marshalled = marshal(this.params[key]);
           if (test instanceof RegExp) {
             const res = evaluators.any[Identities.regexp](test, this.params[key]);
-            if (res) {
+            if (res || res === 0) {
               matches[key] = res;
             } else {
               return {
@@ -110,7 +110,7 @@ export class Query {
         }
       }
 
-      if (Object.keys(matches).length === Object.keys(inbound).length && evaluators.valid[Identities.object](matches)) {
+      if (Object.keys(matches).length === Object.keys(inbound.params).length && evaluators.valid[Identities.object](matches)) {
         return {
           condition: "exact-match",
           matches: marshal(matches).value as Record<string, ReturnParam>
@@ -119,7 +119,7 @@ export class Query {
 
       return {
         condition:
-          Object.keys(matches).length > 1 && Object.keys(inbound).length !== Object.keys(matches).length
+          Object.keys(matches).length > 1 && Object.keys(inbound.params).length !== Object.keys(matches).length
             ? "exact-match"
             : "no-match",
         matches: matches as Record<string, ReturnParam>

--- a/src/lib/query.svelte.ts
+++ b/src/lib/query.svelte.ts
@@ -86,7 +86,8 @@ export class Query {
           const marshalled = marshal(this.params[key]);
           if (test instanceof RegExp) {
             const res = evaluators.any[Identities.regexp](test, this.params[key]);
-            if (typeof res !== 'undefined' && res !== null) {
+            // allow res if the marshalled type matches and is falsy
+            if (res || (typeof res === marshalled.identity && !res)) {
               matches[key] = res;
             } else {
               return {

--- a/src/lib/query.test.ts
+++ b/src/lib/query.test.ts
@@ -14,3 +14,50 @@ describe("query", () => {
     });
   });
 });
+
+describe("query test against inbound", () => {
+  test("single parameter matches exactly", () => {
+    expect(new Query("first=a")
+      .test(new Query({
+        first: /^(\w)$/
+      })))
+      .toEqual({
+        condition: 'exact-match',
+        matches: {
+          first: 'a'
+        }
+      })
+  })
+
+  test("three parameters matches exactly", () => {
+    expect(new Query("first=a&second=b&third=c")
+      .test(new Query({
+        first: /^(\w)$/,
+        second: /^(\w)$/,
+        third: /^(\w)$/,
+      })))
+      .toEqual({
+        condition: 'exact-match',
+        matches: {
+          first: 'a',
+          second: 'b',
+          third: 'c'
+        }
+      })
+  })
+
+  test("0 parses as number", () => {
+    expect(new Query("first=1&second=0")
+      .test(new Query({
+        first: /^(\d)$/,
+        second: /^(\d)$/,
+      })))
+      .toEqual({
+        condition: 'exact-match',
+        matches: {
+          first: 1,
+          second: 0,
+        }
+      })
+  })
+})

--- a/src/lib/query.test.ts
+++ b/src/lib/query.test.ts
@@ -62,15 +62,29 @@ describe("query test against inbound", () => {
   })
 
   test("'false' parses as a parameter", () => {
-    expect(new Query("first=false")
+    expect(new Query("first=false&second=what")
       .test(new Query({
         first: /^(.*)$/,
+        second: /^(.*)$/,
       })))
       .toEqual({
         condition: 'exact-match',
         matches: {
           first: false,
+          second: "what",
         }
       })
   })
+
+  test("requires number, passing string", () => {
+    expect(new Query("first=bad")
+      .test(new Query({
+        first: /^(\d)$/,
+      })))
+      .toEqual({
+        condition: 'no-match'
+      })
+  })
+
 })
+

--- a/src/lib/query.test.ts
+++ b/src/lib/query.test.ts
@@ -60,4 +60,17 @@ describe("query test against inbound", () => {
         }
       })
   })
+
+  test("'false' parses as a parameter", () => {
+    expect(new Query("first=false")
+      .test(new Query({
+        first: /^(.*)$/,
+      })))
+      .toEqual({
+        condition: 'exact-match',
+        matches: {
+          first: false,
+        }
+      })
+  })
 })


### PR DESCRIPTION
Fix for issue https://github.com/mateothegreat/svelte5-router/issues/66 

* compare matchable params to `inbound.params`
* allow ~~the number 0~~ falsy parameters to be parsed and provided in the props