### PR TITLE
fix url parsing for local file urls and add tests

### DIFF
--- a/src/lib/helpers/urls.test.ts
+++ b/src/lib/helpers/urls.test.ts
@@ -7,8 +7,15 @@ test.only("parses with no query parameters", () => {
     protocol: "http",
     host: "localhost",
     port: "5173",
-    path: "/foo/bar",
-    hash: "/foo/bar",
+    path: "/#/foo/bar",
+    hash: {
+      hash: "/foo/bar",
+      path: "/foo/bar",
+      query: {
+        original: "",
+        params: {}
+      },
+    },
     query: {
       original: "",
       params: {}
@@ -17,20 +24,90 @@ test.only("parses with no query parameters", () => {
 });
 
 test.only("parses key-value query parameters", () => {
-  expect(urls.parse("http://localhost:5173/#/foo/bar?negative=-123&a=1&str=string&b=true")).toEqual({
+  let result = urls.parse("http://localhost:5173/#/foo/bar?negative=-123&a=1&str=string&b=true");
+  expect(result).toEqual({
     protocol: "http",
     host: "localhost",
     port: "5173",
-    path: "/foo/bar",
+    path: "/#/foo/bar",
     query: {
       params: {
-        a: "1",
+        negative: -123,
+        a: 1,
         str: "string",
-        b: "true",
-        negative: "-123"
-      }
+        b: true,
+      },
+      original: "negative=-123&a=1&str=string&b=true",
     },
-    hash: "/foo/bar?negative=-123&a=1&str=string&b=true"
+    hash: {
+      path: "/foo/bar",
+      query: {
+        params: {
+          negative: -123,
+          a: 1,
+          str: "string",
+          b: true,
+        },
+        original: "negative=-123&a=1&str=string&b=true",
+      },
+      hash: "/foo/bar?negative=-123&a=1&str=string&b=true",
+    },
+  });
+});
+
+test.only("file url without query parameters", () => {
+  let result = urls.parse("file:///C:/Users/user1/projects/app1/index.html#/foo/bar");
+  expect(result).toEqual({
+    protocol: "file",
+    host: "/C:/Users/user1/projects/app1/index.html",
+    port: "",
+    path: "/#/foo/bar",
+    query: {
+      params: {
+      },
+      original: undefined,
+    },
+    hash: {
+      path: "/foo/bar",
+      query: {
+        params: {
+        },
+        original: "",
+      },
+      hash: "/foo/bar",
+    },
+  });
+});
+
+test.only("file url with key-value query parameters", () => {
+  let result = urls.parse("file:///C:/Users/user1/projects/app1/index.html#/foo/bar?negative=-123&a=1&str=string&b=true");
+  expect(result).toEqual({
+    protocol: "file",
+    host: "/C:/Users/user1/projects/app1/index.html",
+    port: "",
+    path: "/#/foo/bar?negative=-123&a=1&str=string&b=true",
+    query: {
+      params: {
+        negative: -123,
+        a: 1,
+        str: "string",
+        b: true,
+      },
+      original: "negative=-123&a=1&str=string&b=true",
+    },
+    hash: {
+      path: "/foo/bar",
+      query: {
+        params: {
+          negative: -123,
+          a: 1,
+          str: "string",
+          b: true,
+        },
+        original: "negative=-123&a=1&str=string&b=true",
+      },
+      hash: "/foo/bar?negative=-123&a=1&str=string&b=true",
+    },
   });
 });
 


### PR DESCRIPTION
Hi @mateothegreat,

I have the use case where I use your router in a project where the html is loaded from disk (like in an electron app) and had the issue that your url parsing does not cover this.
So I decided to enhance the url parser and add a case for handling file:/// urls. I kept everything else unchanged so it does not break existing behaviour.

Please have a look, it would be really nice to have this upstream, so I can get rid of my fork in my project.

Regards,
Juri