### PR TITLE
Update package.json exports to correct Vite "npm run build" behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "types": "./router.svelte.d.ts",
   "exports": {
     ".": {
-      "types": "./index.js",
-      "import": "./index.js",
-      "svelte": "./index.js"
+      "types": "./dist/index.js",
+      "import": "./dist/index.js",
+      "svelte": "./dist/index.js"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "types": "./router.svelte.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.js",
-      "import": "./dist/index.js",
-      "svelte": "./dist/index.js"
+      "types": "./src/lib/index.ts",
+      "import": "./src/lib/index.ts",
+      "svelte": "./src/lib/index.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Hi there,

It seems like the exports path should be "./dist/index.js" instead of "./index.js". The latter throws me an error when running "vite build".