### PR TITLE
Remove router property from RouteResult example

### DIFF
--- a/src/lib/route.svelte.ts
+++ b/src/lib/route.svelte.ts
@@ -29,7 +29,6 @@ import { urls, type ReturnParam } from "./helpers/urls";
  * @example
  * ```ts
  * const routeResult = new RouteResult({
- *   router: myRouter,
  *   route: myRoute,
  *   result: {
  *     path: {


### PR DESCRIPTION
Since the property was removed in the current version, the example should be updated too. 